### PR TITLE
feat: Request deduplication

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -64,8 +64,8 @@ type Client[T any] struct {
 	shards             []*shard[T]
 	nextShard          int
 	inFlightMutex      sync.Mutex
-	inFlightMap        map[string]*inFlightCall[T]
 	inFlightBatchMutex sync.Mutex
+	inFlightMap        map[string]*inFlightCall[T]
 	inFlightBatchMap   map[string]*inFlightCall[map[string]T]
 }
 

--- a/cache.go
+++ b/cache.go
@@ -63,10 +63,10 @@ type Client[T any] struct {
 	*Config
 	shards             []*shard[T]
 	nextShard          int
-	inflightMutex      sync.Mutex
-	inflightMap        map[string]*call[T]
-	inflightBatchMutex sync.Mutex
-	inflightBatchMap   map[string]*call[map[string]T]
+	inFlightMutex      sync.Mutex
+	inFlightMap        map[string]*inFlightCall[T]
+	inFlightBatchMutex sync.Mutex
+	inFlightBatchMap   map[string]*inFlightCall[map[string]T]
 }
 
 // New creates a new Client instance with the specified configuration.
@@ -78,8 +78,8 @@ type Client[T any] struct {
 // `opts` allows for additional configurations to be applied to the cache client.
 func New[T any](capacity, numShards int, ttl time.Duration, evictionPercentage int, opts ...Option) *Client[T] {
 	client := &Client[T]{
-		inflightMap:      make(map[string]*call[T]),
-		inflightBatchMap: make(map[string]*call[map[string]T]),
+		inFlightMap:      make(map[string]*inFlightCall[T]),
+		inFlightBatchMap: make(map[string]*inFlightCall[map[string]T]),
 	}
 
 	// Create a default configuration, and then apply the options.

--- a/fetch.go
+++ b/fetch.go
@@ -88,7 +88,8 @@ func (c *Client[T]) GetFetchBatch(ctx context.Context, ids []string, keyFn KeyFn
 		return cachedRecords, nil
 	}
 
-	response, err := callAndCacheBatch(ctx, c, cacheMisses, keyFn, fetchFn)
+	callBatchOpts := callBatchOpts[T, T]{ids: cacheMisses, keyFn: keyFn, fn: fetchFn}
+	response, err := callAndCacheBatch(ctx, c, callBatchOpts)
 	if err != nil {
 		if len(cachedRecords) > 0 {
 			return cachedRecords, ErrOnlyCachedRecords

--- a/inflight.go
+++ b/inflight.go
@@ -1,0 +1,169 @@
+package sturdyc
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+type inFlightCall[T any] struct {
+	sync.WaitGroup
+	val T
+	err error
+}
+
+// newFlight should be called with a lock.
+func (c *Client[T]) newFlight(key string) *inFlightCall[T] {
+	call := new(inFlightCall[T])
+	call.Add(1)
+	c.inFlightMap[key] = call
+	return call
+}
+
+// newBatchFlight should be called with a lock.
+func (c *Client[T]) newBatchFlight(ids []string, keyFn KeyFn) *inFlightCall[map[string]T] {
+	call := new(inFlightCall[map[string]T])
+	call.val = make(map[string]T, len(ids))
+	call.Add(1)
+	for _, id := range ids {
+		c.inFlightBatchMap[keyFn(id)] = call
+	}
+	return call
+}
+
+func (c *Client[T]) endFlight(call *inFlightCall[T], key string) {
+	call.Done()
+	c.inFlightMutex.Lock()
+	delete(c.inFlightMap, key)
+	c.inFlightMutex.Unlock()
+}
+
+func (c *Client[T]) endBatchFlight(ids []string, keyFn KeyFn, call *inFlightCall[map[string]T]) {
+	call.Done()
+	c.inFlightBatchMutex.Lock()
+	for _, id := range ids {
+		delete(c.inFlightBatchMap, keyFn(id))
+	}
+	c.inFlightBatchMutex.Unlock()
+}
+
+func (c *Client[T]) endErrorFlight(call *inFlightCall[T], key string, err error) error {
+	call.err = err
+	c.endFlight(call, key)
+	return err
+}
+
+func callAndCache[V, T any](ctx context.Context, c *Client[T], key string, fn FetchFn[V]) (V, error) {
+	c.inFlightMutex.Lock()
+	if call, ok := c.inFlightMap[key]; ok {
+		c.inFlightMutex.Unlock()
+		call.Wait()
+		return unwrap[V, T](call.val, call.err)
+	}
+
+	call := c.newFlight(key)
+	c.inFlightMutex.Unlock()
+
+	response, err := fn(ctx)
+	if err != nil && c.storeMisses && errors.Is(err, ErrStoreMissingRecord) {
+		c.SetMissing(key, *new(T), true)
+		return response, c.endErrorFlight(call, key, ErrMissingRecord)
+	}
+
+	if err != nil {
+		return response, c.endErrorFlight(call, key, err)
+	}
+
+	res, ok := any(response).(T)
+	if !ok {
+		return response, c.endErrorFlight(call, key, ErrInvalidType)
+	}
+
+	c.SetMissing(key, res, false)
+	call.val = res
+	call.err = nil
+	c.endFlight(call, key)
+	return response, nil
+}
+
+func callAndCacheBatch[V, T any](ctx context.Context, c *Client[T], ids []string, keyFn KeyFn, fn BatchFetchFn[V]) (map[string]V, error) {
+	c.inFlightBatchMutex.Lock()
+
+	// We need to keep track of the specific IDs we're after for a particular call.
+	callIDs := make(map[*inFlightCall[map[string]T]][]string)
+	uniqueIDs := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if call, ok := c.inFlightBatchMap[keyFn(id)]; ok {
+			callIDs[call] = append(callIDs[call], id)
+			continue
+		}
+		uniqueIDs = append(uniqueIDs, id)
+	}
+
+	if len(uniqueIDs) > 0 {
+		call := c.newBatchFlight(uniqueIDs, keyFn)
+		for _, id := range uniqueIDs {
+			c.inFlightBatchMap[keyFn(id)] = call
+			callIDs[call] = append(callIDs[call], id)
+		}
+
+		c.inFlightBatchMutex.Unlock()
+		safeGo(func() {
+			response, err := fn(ctx, uniqueIDs)
+			if err != nil {
+				call.err = err
+				c.endBatchFlight(uniqueIDs, keyFn, call)
+				return
+			}
+
+			// Check if we should store any of these IDs as a missing record.
+			if c.storeMisses && len(response) < len(uniqueIDs) {
+				for _, id := range uniqueIDs {
+					if _, ok := response[id]; !ok {
+						var zero T
+						c.SetMissing(keyFn(id), zero, true)
+					}
+				}
+			}
+
+			// Store the records in the cache.
+			for id, record := range response {
+				v, ok := any(record).(T)
+				if !ok {
+					continue
+				}
+				c.SetMissing(keyFn(id), v, false)
+				call.val[id] = v
+			}
+			c.endBatchFlight(uniqueIDs, keyFn, call)
+		})
+	} else {
+		c.inFlightBatchMutex.Unlock()
+	}
+
+	response := make(map[string]V, len(ids))
+	for call, callIDs := range callIDs {
+		call.Wait()
+		if call.err != nil {
+			return response, call.err
+		}
+
+		// Remember: we need to iterate through the values we have for
+		// this call. We might just need one ID in a batch of a hundred.
+		for _, id := range callIDs {
+			v, ok := call.val[id]
+			if !ok {
+				continue
+			}
+
+			if val, ok := any(v).(V); ok {
+				response[id] = val
+			} else {
+				// TODO: Think about this.
+				return response, ErrInvalidType
+			}
+		}
+	}
+
+	return response, nil
+}

--- a/inflight.go
+++ b/inflight.go
@@ -159,7 +159,6 @@ func callAndCacheBatch[V, T any](ctx context.Context, c *Client[T], ids []string
 			if val, ok := any(v).(V); ok {
 				response[id] = val
 			} else {
-				// TODO: Think about this.
 				return response, ErrInvalidType
 			}
 		}

--- a/inflight_test.go
+++ b/inflight_test.go
@@ -2,6 +2,8 @@ package sturdyc_test
 
 import (
 	"context"
+	"math/rand/v2"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -14,7 +16,7 @@ func TestRequestsForMissingKeysGetDeduplicated(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	capacity := 5
+	capacity := 100
 	numShards := 2
 	ttl := time.Minute
 	evictionPercentage := 10
@@ -46,5 +48,90 @@ func TestRequestsForMissingKeysGetDeduplicated(t *testing.T) {
 	wg.Wait()
 	if got := calls.Load(); got != 1 {
 		t.Errorf("got %d calls; wanted 1", got)
+	}
+}
+
+func createBatchFn(calls *atomic.Int32, cond *sync.Cond) sturdyc.BatchFetchFn[int] {
+	return func(_ context.Context, ids []string) (map[string]int, error) {
+		calls.Add(1)
+		vals := make(map[string]int, len(ids))
+		for _, id := range ids {
+			val, err := strconv.Atoi(id)
+			if err != nil {
+				panic(err)
+			}
+			vals[id] = val
+		}
+
+		cond.L.Lock()
+		cond.Wait()
+		cond.L.Unlock()
+
+		return vals, nil
+	}
+}
+
+func TestBatchRequestsForMissingKeysGetDeduplicated(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	capacity := 200
+	numShards := 2
+	ttl := time.Minute
+	evictionPercentage := 10
+	c := sturdyc.New[int](capacity, numShards, ttl, evictionPercentage)
+
+	// I'm going to start by creating three in-flight batches with 5 IDs each.
+	var calls atomic.Int32
+	cond := sync.NewCond(&sync.Mutex{})
+	keyFn := c.BatchKeyFn("foo")
+
+	go func() {
+		c.GetFetchBatch(ctx, []string{"0", "1", "2", "3", "4"}, keyFn, createBatchFn(&calls, cond))
+	}()
+	go func() {
+		c.GetFetchBatch(ctx, []string{"5", "6", "7", "8", "9"}, keyFn, createBatchFn(&calls, cond))
+	}()
+	go func() {
+		c.GetFetchBatch(ctx, []string{"10", "11", "12", "13", "14"}, keyFn, createBatchFn(&calls, cond))
+	}()
+
+	// Now, while these batches are in-flight, I'm going to create additional requests for the same IDs in a loop.
+	// On each iteration, I'm going to randomize two IDs between 1 and 15. This ensures that new requests are able
+	// to pick IDs from any of the three in-flight batches and merge them.
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			// We are going to get a few duplicates here too which the cache should be able to handle.
+			ids := []string{strconv.Itoa(rand.IntN(14)), strconv.Itoa(rand.IntN(14))}
+			res, err := c.GetFetchBatch(ctx, ids, keyFn, createBatchFn(&calls, cond))
+			if err != nil {
+				t.Errorf("expected no error got %v", err)
+			}
+			for _, id := range ids {
+				val, ok := res[id]
+				if !ok {
+					t.Errorf("expected res to key %s", id)
+				}
+
+				intVal, err := strconv.Atoi(id)
+				if err != nil {
+					panic(err)
+				}
+
+				if intVal != val {
+					t.Errorf("expected value %d; got %d", intVal, val)
+				}
+			}
+			wg.Done()
+		}()
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	cond.Broadcast()
+	wg.Wait()
+	if got := calls.Load(); got != 3 {
+		t.Errorf("got %d calls; wanted 3", got)
 	}
 }

--- a/inflight_test.go
+++ b/inflight_test.go
@@ -1,0 +1,50 @@
+package sturdyc_test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/creativecreature/sturdyc"
+)
+
+func TestRequestsForMissingKeysGetDeduplicated(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	capacity := 5
+	numShards := 2
+	ttl := time.Minute
+	evictionPercentage := 10
+	c := sturdyc.New[string](capacity, numShards, ttl, evictionPercentage)
+
+	ch := make(chan string)
+	var calls atomic.Int32
+	fn := func(_ context.Context) (string, error) {
+		calls.Add(1)
+		return <-ch, nil
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			v, err := c.GetFetch(ctx, "id-1", fn)
+			if err != nil {
+				t.Error(err)
+			}
+			if v != "value1" {
+				t.Errorf("got %q; want %q", v, "value1")
+			}
+			wg.Done()
+		}()
+	}
+	time.Sleep(50 * time.Millisecond)
+	ch <- "value1"
+	wg.Wait()
+	if got := calls.Load(); got != 1 {
+		t.Errorf("got %d calls; wanted 1", got)
+	}
+}

--- a/passthrough.go
+++ b/passthrough.go
@@ -2,8 +2,29 @@ package sturdyc
 
 import (
 	"context"
+	"errors"
 	"math/rand/v2"
 )
+
+func passthroughAndCache[V, T any](ctx context.Context, c *Client[T], key string, fetchFn FetchFn[V]) (V, error) {
+	response, err := fetchFn(ctx)
+	if err != nil && c.storeMisses && errors.Is(err, ErrStoreMissingRecord) {
+		c.SetMissing(key, *new(T), true)
+		return response, ErrMissingRecord
+	}
+
+	if err != nil {
+		return response, err
+	}
+
+	res, ok := any(response).(T)
+	if !ok {
+		return response, ErrInvalidType
+	}
+
+	c.SetMissing(key, res, false)
+	return response, nil
+}
 
 // Passthrough attempts to retrieve the id from the cache. If looking up the ID
 // results in a cache miss, it will fetch the record using the fetchFn. If the
@@ -21,13 +42,40 @@ func (c *Client[T]) Passthrough(ctx context.Context, key string, fetchFn FetchFn
 		}
 		return value, nil
 	}
-	return callAndCache(ctx, c, key, fetchFn)
+	return passthroughAndCache(ctx, c, key, fetchFn)
 }
 
 // Passthrough is a convenience function that performs type assertion on the result of client.Passthrough.
 func Passthrough[T, V any](ctx context.Context, c *Client[T], key string, fetchFn FetchFn[V]) (V, error) {
 	value, err := c.Passthrough(ctx, key, wrap[T](fetchFn))
 	return unwrap[V](value, err)
+}
+
+func passthroughAndCacheBatch[V, T any](ctx context.Context, c *Client[T], ids []string, keyFn KeyFn, fetchFn BatchFetchFn[V]) (map[string]V, error) {
+	response, err := fetchFn(ctx, ids)
+	if err != nil {
+		return response, err
+	}
+
+	// Check if we should store any of these IDs as a missing record.
+	if c.storeMisses && len(response) < len(ids) {
+		for _, id := range ids {
+			if _, ok := response[id]; !ok {
+				c.SetMissing(keyFn(id), *new(T), true)
+			}
+		}
+	}
+
+	// Store the records in the cache.
+	for id, record := range response {
+		v, ok := any(record).(T)
+		if !ok {
+			continue
+		}
+		c.SetMissing(keyFn(id), v, false)
+	}
+
+	return response, nil
 }
 
 // PassthroughBatch attempts to retrieve the ids from the cache. If looking up
@@ -42,7 +90,7 @@ func (c *Client[T]) PassthroughBatch(ctx context.Context, ids []string, keyFn Ke
 	// If we have cache misses, we're going to perform an outgoing refresh
 	// regardless. We'll utilize this to perform a passthrough for all IDs.
 	if len(cacheMisses) > 0 {
-		res, err := callAndCacheBatch(ctx, c, ids, keyFn, fetchFn)
+		res, err := passthroughAndCacheBatch(ctx, c, ids, keyFn, fetchFn)
 		if err != nil && len(cachedRecords) > 0 {
 			return cachedRecords, ErrOnlyCachedRecords
 		}

--- a/passthrough.go
+++ b/passthrough.go
@@ -21,7 +21,7 @@ func (c *Client[T]) Passthrough(ctx context.Context, key string, fetchFn FetchFn
 		}
 		return value, nil
 	}
-	return fetchAndCache(ctx, c, key, fetchFn)
+	return callAndCache(ctx, c, key, fetchFn)
 }
 
 // Passthrough is a convenience function that performs type assertion on the result of client.Passthrough.
@@ -42,7 +42,7 @@ func (c *Client[T]) PassthroughBatch(ctx context.Context, ids []string, keyFn Ke
 	// If we have cache misses, we're going to perform an outgoing refresh
 	// regardless. We'll utilize this to perform a passthrough for all IDs.
 	if len(cacheMisses) > 0 {
-		res, err := fetchAndCacheBatch(ctx, c, ids, keyFn, fetchFn)
+		res, err := callAndCacheBatch(ctx, c, ids, keyFn, fetchFn)
 		if err != nil && len(cachedRecords) > 0 {
 			return cachedRecords, ErrOnlyCachedRecords
 		}


### PR DESCRIPTION
## Overview
This PR adds request deduplication by making the cache track in-flight requests for keys. This works for batchable endpoints too, as the cache is able to cherry-pick the keys it needs from different outgoing batches.