### PR TITLE
build: downgrade go => 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/creativecreature/sturdyc
 
-go 1.22.1
+go 1.21
 
 require github.com/google/go-cmp v0.6.0
 


### PR DESCRIPTION
`sturdyc` doesn't require any Go 1.22 features. So I think it's better to lower the Go version requirement.

And since built-in `max` is used, 1.21 is the lowest supported version.