### PR TITLE
fix: Partial responses from the distributed storage could result in faulty missing records

### DIFF
--- a/distribution.go
+++ b/distribution.go
@@ -219,13 +219,16 @@ func distributedBatchFetch[V, T any](c *Client[T], keyFn KeyFn, fetchFn BatchFet
 
 		dataSourceResponses, err := fetchFn(ctx, idsToRefresh)
 		// In case of an error, we'll proceed with the ones we got from the distributed storage.
+		// NOTE: It's important that we return a specific error here, otherwise we'll potentially
+		// end up caching the IDs that we weren't able to retrieve from the underlying data source
+		// as missing records.
 		if err != nil {
 			for i := 0; i < len(stale); i++ {
 				c.reportDistributedStaleFallback()
 			}
 			c.log.Error(fmt.Sprintf("sturdyc: error fetching records from the underlying data source. %v", err))
 			maps.Copy(stale, fresh)
-			return stale, nil
+			return stale, errOnlyDistributedRecords
 		}
 
 		// Next, we'll want to check if we should change any of the records to be missing or perform deletions.

--- a/distribution.go
+++ b/distribution.go
@@ -191,7 +191,7 @@ func distributedBatchFetch[V, T any](c *Client[T], keyFn KeyFn, fetchFn BatchFet
 				continue
 			}
 
-			// If distributedStaleStorage isn't enabled it means all records are fresh, otherwise checked the CreatedAt time.
+			// If early refreshes isn't enabled it means all records are fresh, otherwise we'll check the CreatedAt time.
 			if !c.distributedEarlyRefreshes || c.clock.Since(record.CreatedAt) < c.distributedRefreshAfterDuration {
 				// We never want to return missing records.
 				if !record.IsMissingRecord {

--- a/distribution_test.go
+++ b/distribution_test.go
@@ -499,8 +499,8 @@ func TestDistributedStaleStorageBatch(t *testing.T) {
 	fetchObserver.Err(errors.New("error"))
 
 	res, err := sturdyc.GetOrFetchBatch(ctx, c, firstBatchOfIDs, keyFn, fetchObserver.FetchBatch)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+	if !errors.Is(err, sturdyc.ErrOnlyCachedRecords) {
+		t.Fatalf("expected ErrOnlyCachedRecords, got %v", err)
 	}
 	for id, value := range res {
 		if value != "value"+id {
@@ -748,8 +748,8 @@ func TestDistributedStorageDoesNotCachePartialResponseAsMissingRecords(t *testin
 	secondBatchOfIDs := []string{"1", "2", "3", "4"}
 	fetchObserver.Err(errors.New("boom"))
 	res, err := sturdyc.GetOrFetchBatch(ctx, c, secondBatchOfIDs, keyFn, fetchObserver.FetchBatch)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+	if !errors.Is(err, sturdyc.ErrOnlyCachedRecords) {
+		t.Fatalf("expected ErrOnlyCachedRecords, got %v", err)
 	}
 	if len(res) != 3 {
 		t.Fatalf("expected 3 records, got %d", len(res))
@@ -842,8 +842,8 @@ func TestPartialResponseForRefreshesDoesNotResultInMissingRecords(t *testing.T) 
 		secondBatchOfIDs = append(secondBatchOfIDs, strconv.Itoa(i))
 	}
 	res, err = sturdyc.GetOrFetchBatch(ctx, c, secondBatchOfIDs, keyFn, fetchObserver.FetchBatch)
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
+	if !errors.Is(err, sturdyc.ErrOnlyCachedRecords) {
+		t.Fatalf("expected ErrOnlyCachedRecords, got %v", err)
 	}
 	if len(res) != 100 {
 		t.Fatalf("expected 100 records, got %d", len(res))

--- a/errors.go
+++ b/errors.go
@@ -3,6 +3,10 @@ package sturdyc
 import "errors"
 
 var (
+	// errOnlyDistributedRecords is an internal error that the cache uses to not
+	// store records as missing if it's unable to get part of the batch from the
+	// underlying data source.
+	errOnlyDistributedRecords = errors.New("sturdyc: we were only able to get records from the distributed storage")
 	// ErrNotFound should be returned from a FetchFn to indicate that a record is
 	// missing at the underlying data source. This helps the cache to determine
 	// if a record should be deleted or stored as a missing record if you have

--- a/fetch.go
+++ b/fetch.go
@@ -2,6 +2,7 @@ package sturdyc
 
 import (
 	"context"
+	"errors"
 	"maps"
 )
 
@@ -118,7 +119,7 @@ func getFetchBatch[V, T any](ctx context.Context, c *Client[T], ids []string, ke
 
 	callBatchOpts := callBatchOpts[T, T]{ids: cacheMisses, keyFn: keyFn, fn: wrappedFetch}
 	response, err := callAndCacheBatch(ctx, c, callBatchOpts)
-	if err != nil {
+	if err != nil && !errors.Is(err, ErrOnlyCachedRecords) {
 		if len(cachedRecords) > 0 {
 			return cachedRecords, ErrOnlyCachedRecords
 		}
@@ -126,7 +127,7 @@ func getFetchBatch[V, T any](ctx context.Context, c *Client[T], ids []string, ke
 	}
 
 	maps.Copy(cachedRecords, response)
-	return cachedRecords, nil
+	return cachedRecords, err
 }
 
 // GetOrFetchBatch attempts to retrieve the specified ids from the cache. If

--- a/safe.go
+++ b/safe.go
@@ -2,6 +2,7 @@ package sturdyc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 )
 
@@ -51,7 +52,7 @@ func unwrap[V, T any](val T, err error) (V, error) {
 func wrapBatch[T, V any](fetchFn BatchFetchFn[V]) BatchFetchFn[T] {
 	return func(ctx context.Context, ids []string) (map[string]T, error) {
 		resV, err := fetchFn(ctx, ids)
-		if err != nil {
+		if err != nil && !errors.Is(err, errOnlyDistributedRecords) {
 			return map[string]T{}, err
 		}
 
@@ -64,7 +65,7 @@ func wrapBatch[T, V any](fetchFn BatchFetchFn[V]) BatchFetchFn[T] {
 			resT[id] = val
 		}
 
-		return resT, nil
+		return resT, err
 	}
 }
 


### PR DESCRIPTION
## Overview
If we are able to retrieve some IDs from a distributed storage, but the call to fetch the remaining IDs fails, those IDs would be cached as missing records if the setting is enabled.